### PR TITLE
teensy-3-rust: updates for post-1.11 nightly.

### DIFF
--- a/teensy-3-rust/Cargo.toml
+++ b/teensy-3-rust/Cargo.toml
@@ -4,13 +4,15 @@ version = "0.1.0"
 authors = ["Michael Daffin <michael@daffin.io>"]
 build = "build.rs"
 
+[dependencies]
+rust-libcore = "*"
+
 [profile.dev]
 opt-level = 0
 debug = true
+panic = "abort"
 
 [profile.release]
 opt-level = 2
 debug = false
-
-[target.thumbv7em-none-eabi.dependencies.core]
-git = "https://github.com/hackndev/rust-libcore"
+panic = "abort"

--- a/teensy-3-rust/src/main.rs
+++ b/teensy-3-rust/src/main.rs
@@ -1,10 +1,8 @@
-#![feature(lang_items,no_std,core_intrinsics,asm,start)]
+#![feature(lang_items,core_intrinsics,asm,start)]
 #![no_std]
-#![crate_type="staticlib"]
 
 use core::intrinsics::{volatile_store};
 
-#[lang="stack_exhausted"] extern fn stack_exhausted() {}
 #[lang="eh_personality"] extern fn eh_personality() {}
 #[lang="panic_fmt"]
 #[no_mangle]

--- a/teensy-3-rust/thumbv7em-none-eabi.json
+++ b/teensy-3-rust/thumbv7em-none-eabi.json
@@ -1,7 +1,7 @@
 {
     "arch": "arm",
     "cpu": "cortex-m4",
-    "data-layout": "e-m:e-p:32:32-i1:8:32-i8:8:32-i16:16:32-i64:64-v128:64:128-a:0:32-n32-S64",
+    "data-layout": "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64",
     "disable-redzone": true,
     "executables": true,
     "llvm-target": "thumbv7em-none-eabi",


### PR DESCRIPTION
This compiles again, and the binary looks reasonable under disassembly.
I have not tested the output on a Teensy (as I don't own one).

Changes:

no_std is no longer behind a feature gate; removed that.

Updated to a more recent copy of Zinc's thumbv7em target with altered
data layout for small integers.  (Otherwise I was getting LLVM asserts
much like farcaller was seeing in Zinc.)  (I preserved your post-link
flags.)

Removed now-meaningless stack_exhausted lang item.

Switched to panic=abort to resolve a bunch of undefined unwinding
symbols.

Switched to libcore from crates.io instead of Zinc's fork.

Removed crate_type="staticlib"; Cargo sets the crate type on rustc's
command line, and this seems to override the attribute.
